### PR TITLE
Switch to sessionStorage for wallet status

### DIFF
--- a/src/external_interfaces/ui/templates/contracts.html
+++ b/src/external_interfaces/ui/templates/contracts.html
@@ -503,8 +503,8 @@ Jurisdiction: Delaware, USA</textarea>
         // Generate Contract button click
         document.getElementById('generateContractBtn').addEventListener('click', function() {
             // Check if wallet is connected
-            const walletConnected = localStorage.getItem('walletConnected') === 'true';
-            const walletAddress = localStorage.getItem('userWalletAddress');
+            const walletConnected = sessionStorage.getItem('walletConnected') === 'true';
+            const walletAddress = sessionStorage.getItem('userWalletAddress');
             
             if (!walletConnected || !walletAddress) {
                 alert('Please connect your wallet first.');
@@ -579,8 +579,8 @@ Jurisdiction: Delaware, USA</textarea>
         // New Contract button click
         document.getElementById('newContractBtn').addEventListener('click', function() {
             // Check if wallet is connected already
-            const walletConnected = localStorage.getItem('walletConnected') === 'true';
-            const walletAddress = localStorage.getItem('userWalletAddress');
+            const walletConnected = sessionStorage.getItem('walletConnected') === 'true';
+            const walletAddress = sessionStorage.getItem('userWalletAddress');
             
             if (walletConnected && walletAddress) {
                 // Proceed with contract creation since wallet is already connected
@@ -625,7 +625,7 @@ Jurisdiction: Delaware, USA</textarea>
                 
                 // Prepare transaction data
                 const transactionData = {
-                    from_address: localStorage.getItem('userWalletAddress'),
+                    from_address: sessionStorage.getItem('userWalletAddress'),
                     to_address: "odiseo1qg5ega6dykkxc307y25pecuv380qje7zp9qpxt", // Contract validator address
                     amount: [{ denom: "uodis", amount: "1000" }],
                     metadata: {
@@ -673,9 +673,9 @@ Jurisdiction: Delaware, USA</textarea>
         
         // Check if the wallet is already connected
         function checkWalletConnection() {
-            // Check localStorage for wallet connection status
-            const walletConnected = localStorage.getItem('walletConnected') === 'true';
-            const walletAddress = localStorage.getItem('userWalletAddress');
+            // Check sessionStorage for wallet connection status
+            const walletConnected = sessionStorage.getItem('walletConnected') === 'true';
+            const walletAddress = sessionStorage.getItem('userWalletAddress');
             
             if (walletConnected && walletAddress) {
                 // Show the wallet address in the input field if it exists

--- a/src/external_interfaces/ui/templates/dashboard.html
+++ b/src/external_interfaces/ui/templates/dashboard.html
@@ -490,9 +490,9 @@
 
         // Check wallet connection when investment modal is opened
         document.getElementById('investModal').addEventListener('show.bs.modal', function() {
-            // Check if wallet is connected (using localStorage)
-            const walletConnected = localStorage.getItem('walletConnected') === 'true';
-            const userWalletAddress = localStorage.getItem('userWalletAddress');
+            // Check if wallet is connected (using sessionStorage)
+            const walletConnected = sessionStorage.getItem('walletConnected') === 'true';
+            const userWalletAddress = sessionStorage.getItem('userWalletAddress');
 
             // Update wallet address field if available
             if (walletConnected && userWalletAddress) {

--- a/src/external_interfaces/ui/templates/upload.html
+++ b/src/external_interfaces/ui/templates/upload.html
@@ -478,8 +478,8 @@
             console.log('Files selected:', files);
             
             // Check if wallet is connected
-            const walletConnected = localStorage.getItem('walletConnected') === 'true';
-            const userWalletAddress = localStorage.getItem('userWalletAddress');
+            const walletConnected = sessionStorage.getItem('walletConnected') === 'true';
+            const userWalletAddress = sessionStorage.getItem('userWalletAddress');
             
             if (!walletConnected || !userWalletAddress) {
                 // Show wallet connection prompt
@@ -500,7 +500,7 @@
                     await connectKeplrWallet();
                     notification.remove();
                     // If connection was successful, proceed with the upload
-                    if (localStorage.getItem('walletConnected') === 'true') {
+                    if (sessionStorage.getItem('walletConnected') === 'true') {
                         handleFiles(files);
                     }
                 });


### PR DESCRIPTION
## Summary
- use `sessionStorage` instead of `localStorage` to track wallet status in UI templates
- update upload, dashboard and contracts templates

## Testing
- `pytest tests/test_bimserver_gateway.py::TestBIMServerGateway -q`
- `pytest tests/test_keplr_message_format_fix.py -q`
- `pytest tests/test_utils.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: openai, security_patch)*

------
https://chatgpt.com/codex/tasks/task_e_6840634aad18832fa61c142ef066e2b6