### PR TITLE
Update broadcast endpoint usage

### DIFF
--- a/src/external_interfaces/ui/static/js/transaction.js
+++ b/src/external_interfaces/ui/static/js/transaction.js
@@ -414,10 +414,13 @@ async function broadcastTransaction(signResponse) {
     console.log("Broadcasting transaction:", JSON.stringify(broadcastBody, null, 2));
 
     // Send to your backend API endpoint that will broadcast to the blockchain
-    const response = await fetch("/api/broadcast", {
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ||
+                      window.csrf_token || '';
+    const response = await fetch("/api/blockchain/broadcast", {
       method: "POST",
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "X-CSRF-Token": csrfToken
       },
       body: JSON.stringify(broadcastBody)
     });
@@ -467,4 +470,5 @@ async function broadcastTransaction(signResponse) {
 
 // Export functions
 window.signContract = signContract;
+window.broadcastTransaction = broadcastTransaction;
 export { createAndSignTransaction };

--- a/src/external_interfaces/ui/templates/upload.html
+++ b/src/external_interfaces/ui/templates/upload.html
@@ -607,20 +607,8 @@
                         const statusBadge = fileItem.querySelector('.badge');
                         statusBadge.textContent = 'Signed';
                         
-                        // Third phase: Broadcast the transaction
-                        const broadcastResponse = await fetch('/api/broadcast', {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json'
-                            },
-                            body: JSON.stringify(signResponse)
-                        });
-                        
-                        if (!broadcastResponse.ok) {
-                            throw new Error(`Server responded with ${broadcastResponse.status}: ${await broadcastResponse.text()}`);
-                        }
-                        
-                        const broadcastData = await broadcastResponse.json();
+                        // Third phase: Broadcast the transaction using helper
+                        const broadcastData = await broadcastTransaction(signResponse);
                         console.log('Transaction broadcast:', broadcastData);
                         
                         if (!broadcastData.success) {


### PR DESCRIPTION
## Summary
- use `broadcastTransaction` helper in upload UI
- send transactions to `/api/blockchain/broadcast` with CSRF token
- expose `broadcastTransaction` globally for inline scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6840727b8570832fb7dcee4116a86d68