### PR TITLE
Use official broadcast enum

### DIFF
--- a/src/controllers/transaction_controller.py
+++ b/src/controllers/transaction_controller.py
@@ -242,7 +242,7 @@ def broadcast_transaction():
                 }],
                 "memo": signed_tx.get("memo", "")
             },
-            "mode": "block"  # Wait for confirmation
+            "mode": "BROADCAST_MODE_BLOCK"  # Wait for confirmation
         }
         
         # Broadcast the transaction

--- a/src/external_interfaces/ui/static/js/transaction.js
+++ b/src/external_interfaces/ui/static/js/transaction.js
@@ -408,7 +408,7 @@ async function broadcastTransaction(signResponse) {
         ],
         memo: signResponse.signed.memo // Use the simple string memo
       },
-      mode: "block" // Use "block" to wait for confirmation
+      mode: "BROADCAST_MODE_BLOCK" // Wait for block confirmation
     };
 
     console.log("Broadcasting transaction:", JSON.stringify(broadcastBody, null, 2));

--- a/src/services/blockchain_service.py
+++ b/src/services/blockchain_service.py
@@ -181,7 +181,7 @@ class BlockchainService:
                 ],
                 "memo": signed_tx.get("signed", {}).get("memo", "")
             },
-            "mode": "block"  # Wait for block confirmation
+            "mode": "BROADCAST_MODE_BLOCK"  # Wait for block confirmation
         }
         
         return broadcast_tx

--- a/src/services/transaction_service.py
+++ b/src/services/transaction_service.py
@@ -328,7 +328,7 @@ class TransactionService:
                 # Prepare the transaction broadcast request in Amino JSON format
                 broadcast_json = {
                     "tx": tx,
-                    "mode": "block",  # Use "block" to wait for confirmation
+                    "mode": "BROADCAST_MODE_BLOCK",  # Wait for block confirmation
                 }
 
                 self.logger.debug(


### PR DESCRIPTION
## Summary
- use Cosmos `BROADCAST_MODE_BLOCK` constant in Python broadcast helpers
- update frontend to send `BROADCAST_MODE_BLOCK`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests', 'cosmpy', 'security_patch')*

------
https://chatgpt.com/codex/tasks/task_e_684081c9f49c832f82e91af1633944e9